### PR TITLE
cargo: Bump prost version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Install tonic's protoc dependencies
+        run: |
+          sudo apt install apt protobuf-compiler libprotobuf-dev
+
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "1ba0d94a900a97aa1bcac032a67ea23766bcfdef" }
 pin-project-lite = "0.2.9"
-prost = { version = "0.10.0", optional = true }
+prost = { version = ">=0.11.0", optional = true }
 rand = ">=0.8"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = ">=1.0"
 sha2 = ">=0.10"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"], optional = true }
-tonic = { version = ">=0.7.0", optional = true }
+tonic = { version = ">=0.8.0", optional = true }
 
 [dev-dependencies]
 openssl = ">=0.10"

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -226,7 +226,7 @@ fn decrypt_layer_key_opts_data(dc: &DecryptConfig, desc: &OciDescriptor) -> Resu
                     priv_key_given = true;
                 }
 
-                if let Ok(opts_data) = pre_unwrap_key(&*keywrapper, dc, b64_annotation) {
+                if let Ok(opts_data) = pre_unwrap_key(keywrapper, dc, b64_annotation) {
                     if !opts_data.is_empty() {
                         return Ok(opts_data);
                     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -104,10 +104,9 @@ fn process_pwd_string(pwd_string: String) -> Result<Vec<u8>> {
     } else if let Some(pwd) = pwd_string.strip_prefix("fd=") {
         let fd = pwd.parse::<i32>().unwrap();
         let mut fd_file = unsafe { File::from_raw_fd(fd) };
-        let mut contents = vec![];
-        fd_file.read_exact(&mut contents)?;
-
-        return Ok(contents);
+        let mut contents = String::new();
+        fd_file.read_to_string(&mut contents)?;
+        return Ok(contents.as_bytes().to_vec());
     }
 
     Ok(pwd_string.as_bytes().to_vec())


### PR DESCRIPTION
Now ocicryprt-rs is picking up 0.8.0 of tonic, it needs to use 0.11.0
of post

Whether we want to have `>=` versions of dependencies and risk them getting
out of sync - I'm not sure, but hopefully
this fixes the build problems in the short term

Fixes: confidential-containers/guest-components#260
Signed-off-by: stevenhorsman <steven@uk.ibm.com>