### PR TITLE
Use keyprovider from OCICRYPT_KEYPROVIDER_CONFIG during decryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures = { version = "0.3.21", optional = true }
 hmac = ">=0.12"
 josekit = { version = ">=0.7", optional = true }
 lazy_static = ">=1.4"
-oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "1ba0d94a900a97aa1bcac032a67ea23766bcfdef" }
+oci-distribution = "0.9.3"
 openssl = { version = ">=0.10", features = ["vendored"] }
 pin-project-lite = "0.2.9"
 prost = { version = ">=0.11.0", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ use std::io::BufReader;
 use anyhow::{anyhow, Result};
 use serde::{de, Deserializer, Serialize, Serializer};
 
+/// OCICRYPT_ENVVARNAME is the environment name for ocicrypt provider config file,
+/// the key will be "OCICRYPT_KEYPROVIDER_CONFIG" and format is defined at:
+/// <https://github.com/containers/ocicrypt/blob/main/docs/keyprovider.md>
 pub const OCICRYPT_ENVVARNAME: &str = "OCICRYPT_KEYPROVIDER_CONFIG";
 
 /// DecryptConfig wraps the Parameters map that holds the decryption key
@@ -84,7 +87,9 @@ pub struct KeyProviderAttrs {
     pub native: Option<String>,
 }
 
-/// OcicryptConfig represents the format of an ocicrypt_provider.conf config file
+/// OcicryptConfig represents the format of an ocicrypt_provider.conf config file.
+/// Detail ocicrypt keyprovider protocol and config file format is defined at:
+/// <https://github.com/containers/ocicrypt/blob/main/docs/keyprovider.md>
 #[derive(Deserialize)]
 pub struct OcicryptConfig {
     #[serde(rename = "key-providers")]


### PR DESCRIPTION
During decryption, ignore keyprovider name in annotations and use the
keyprovider defined in OCICRYPT_KEYPROVIDER_CONFIG.

Fixes: confidential-containers/guest-components#259
