### PR TITLE
fix: timeout for ttrpc

### DIFF
--- a/src/keywrap/keyprovider.rs
+++ b/src/keywrap/keyprovider.rs
@@ -143,7 +143,7 @@ impl KeyProviderKeyWrapProtocolOutput {
 
         let ttrpc_output = match operation {
             OpKey::Wrap => kc1
-                .wrap_key(ttrpc::context::with_timeout(20 * 1000 * 1000), &req)
+                .wrap_key(ttrpc::context::with_timeout(10 * 1000 * 1000 * 1000), &req)
                 .await
                 .map_err(|_| {
                     anyhow!(
@@ -153,7 +153,7 @@ impl KeyProviderKeyWrapProtocolOutput {
                 })?,
 
             OpKey::Unwrap => kc1
-                .un_wrap_key(ttrpc::context::with_timeout(20 * 1000 * 1000), &req)
+                .un_wrap_key(ttrpc::context::with_timeout(10 * 1000 * 1000 * 1000), &req)
                 .await
                 .map_err(|_| {
                     anyhow!(


### PR DESCRIPTION
bring ttrpc timeout to 10 seconds for backend remote attestation

Fixes confidential-containers/guest-components#256