### PR TITLE
Feature: add `openssl` and `ring` to implement block cipher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,17 @@ jobs:
           command: build
           args: --no-default-features
 
-      - name: Run cargo build - block cipher
+      - name: Run cargo build - block cipher openssl
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --features=block-cipher
+          args: --no-default-features --features=block-cipher-openssl
+
+      - name: Run cargo build - block cipher ring
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --features=block-cipher-ring
 
       - name: Run cargo build - keywrap-jwe
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ aes = { version = ">=0.8", optional = true }
 async-trait = { version = "0.1.61", optional = true }
 base64 = "0.13"
 base64-serde = { version = "0.6", optional = true }
+cfg-if = "1.0.0"
 ctr = { version = ">=0.9", optional = true }
 hmac = { version = ">=0.12", optional = true }
 josekit = { version = ">=0.7", optional = true }
@@ -22,6 +23,7 @@ openssl = { version = ">=0.10", features = ["vendored"], optional = true }
 pin-project-lite = { version = "0.2.9", optional = true }
 protobuf = { version = "3.2.0", optional = true }
 prost = { version = ">=0.11.0", optional = true }
+ring = { version = "0.16.20", optional = true}
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = ">=1.0"
 sha2 = { version = ">=0.10", optional = true }
@@ -36,13 +38,20 @@ ttrpc-codegen = { version = "0.4.1", optional = true }
 
 [dev-dependencies]
 aes-gcm = { version = "0.10" }
+openssl = { version = ">=0.10", features = ["vendored"]}
 tokio = { version = "1.17.0", features = ["time", "signal"] }
 
 [features]
-default = ["block-cipher", "keywrap-jwe", "keywrap-keyprovider-cmd"]
+default = ["block-cipher-openssl", "keywrap-jwe", "keywrap-keyprovider-cmd"]
 eaa_kbc = ["keywrap-keyprovider-native", "attestation_agent/eaa_kbc"]
 async-io = ["tokio"]
-block-cipher = ["aes", "base64-serde", "ctr", "hmac", "openssl", "pin-project-lite", "sha2"]
+
+block-cipher = []
+# Use ring as pseudo random number generator
+block-cipher-ring = ["aes", "base64-serde", "ctr", "hmac", "ring", "pin-project-lite", "sha2", "block-cipher"]
+# Use openssl as pseudo random number generator
+block-cipher-openssl = ["aes", "base64-serde", "ctr", "hmac", "openssl", "pin-project-lite", "sha2", "block-cipher"]
+
 keywrap-jwe = ["josekit"]
 keywrap-keyprovider = []
 keywrap-keyprovider-cmd = ["keywrap-keyprovider"]

--- a/src/blockcipher/aes_ctr.rs
+++ b/src/blockcipher/aes_ctr.rs
@@ -7,10 +7,11 @@ use anyhow::{anyhow, Result};
 use ctr::cipher::generic_array::GenericArray;
 use ctr::cipher::{KeyIvInit, StreamCipher};
 use hmac::{Hmac, Mac};
-use openssl::rand::rand_bytes;
 use sha2::Sha256;
 
 use crate::blockcipher::{EncryptionFinalizer, LayerBlockCipher, LayerBlockCipherOptions};
+
+use super::rand::rand_bytes;
 
 const AES256_KEY_SIZE: usize = 32;
 const AES256_NONCE_SIZE: usize = 16;

--- a/src/blockcipher/mod.rs
+++ b/src/blockcipher/mod.rs
@@ -11,6 +11,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 mod aes_ctr;
 use aes_ctr::AESCTRBlockCipher;
 
+mod rand;
+
 /// Type of the cipher algorithm used to encrypt/decrypt image layers.
 pub type LayerCipherType = String;
 

--- a/src/blockcipher/rand.rs
+++ b/src/blockcipher/rand.rs
@@ -1,0 +1,28 @@
+// Copyright The ocicrypt Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+/// Fill the given slice with cryptographically generated random numbers
+pub(crate) fn rand_bytes(data: &mut [u8]) -> Result<()> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "block-cipher-openssl")] {
+            openssl::rand::rand_bytes(&mut data[..])?;
+        } else if #[cfg(feature = "block-cipher-ring")] {
+            use ring::rand::SecureRandom;
+            ring::rand::SystemRandom::new().fill(&mut data[..]).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::blockcipher::rand::rand_bytes;
+
+    #[test]
+    fn fill_random_bytes() {
+        let mut data = vec![9; 0];
+        assert!(rand_bytes(&mut data).is_ok());
+    }
+}


### PR DESCRIPTION
`ring` crate can provide the same random generator function
as `openssl`. We add two features to implement rand_bytes

- `block-cipher-ring`: based on ring, which is purely rust but
cannot be built on some arch like `s390x`.
- `block-cipher-openssl`: based on vendored openssl, but it
requires `Make`, `C` compiler and `perl`.

Fixes: confidential-containers/guest-components#255